### PR TITLE
call the builder.py script from the setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setuptools.setup(
     license="Apache License Version 2.0",
     url="https://github.com/ecmwf/eccodes-python",
     packages=setuptools.find_packages(),
+    setup_requires=["cffi"],
+    cffi_modules=["builder.py:ffibuilder"],
     include_package_data=True,
     install_requires=["attrs", "cffi", "numpy",],
     tests_require=["pytest", "pytest-cov", "pytest-flakes",],


### PR DESCRIPTION
This will automatically build the fast cffi based bindings.
An additional advantage is that the python module gets installed below /usr/lib64/python3.x/site-packages/ now and no longer below /usr/lib/python3.x/site-packages/
When manually calling the builder.py script after having done a "setup.py build", and then adding it to the build directory, and calling "setup.py install", the module ends up below /usr/lib.
This is especially important when packaging the module for a linux distribution (as I am trying to do now for Fedora), since there are strict guidelines where binary python packages need to be installed.

In case you do not wish to have a call to this builder.py script in a default install, please consider adding it as an option to the setup.py script, so it can be enabled if needed.