### PR TITLE
#30: Fix segfault from invalid pointer reference in grib_set_double_array()

### DIFF
--- a/gribapi/gribapi.py
+++ b/gribapi/gribapi.py
@@ -1140,16 +1140,18 @@ def grib_set_double_array(msgid, key, inarray):
     """
     h = get_handle(msgid)
     length = len(inarray)
-    a = inarray
     if isinstance(inarray, np.ndarray):
+        nd = inarray
         if length > 0:
-            if not isinstance(a[0], float):
+            if not isinstance(nd[0], float):
                 # ECC-1042: input array of integers
-                a = a.astype(float)
+                nd = nd.astype(float)
         # ECC-1007: Could also call numpy.ascontiguousarray
         if not inarray.flags["C_CONTIGUOUS"]:
-            a = a.copy(order="C")
-        a = ffi.cast("double*", a.ctypes.data)
+            nd = nd.copy(order="C")
+        a = ffi.cast("double*", nd.ctypes.data)
+    else:
+        a = inarray
 
     GRIB_CHECK(lib.grib_set_double_array(h, key.encode(ENC), a, length))
 

--- a/tests/test_eccodes.py
+++ b/tests/test_eccodes.py
@@ -400,6 +400,14 @@ def test_grib_ecc_1007():
     codes_release(gid)
 
 
+def test_grib_float_array():
+    gid = codes_grib_new_from_samples("regular_ll_sfc_grib2")
+    values = np.ones((100000,), np.float32)
+    codes_set_values(gid, values)
+    getvals = codes_get_values(gid)
+    assert (getvals == 1.0).all()
+
+
 def test_gribex_mode():
     codes_gribex_mode_on()
     codes_gribex_mode_off()


### PR DESCRIPTION
This PR aims to fix a problem in grib_set_double_array() which can lead to a segfault against numpy versions from 1.17.4 onwards.

The segfault seems to occur due to using a numpy array's `ctypes.data` as the target for an `ffi.cast`, and then immediately overwriting the numpy array with the results of the cast.

The fix is simply to avoid overwriting the numpy array altogether, and keep the FFI ctype object in its own variable.

