### PR TITLE
Remove the apparent support for Python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [aliases]
 test = pytest
 


### PR DESCRIPTION
`universal = 1` is used to claim single source support for Python versions 2 and 3, but the code is using python3-only syntax.