### PR TITLE
Run CI on HPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,15 @@ on:
   # Trigger the workflow manually
   workflow_dispatch: ~
 
+  # Trigger after public PR approved for CI
+  pull_request_target:
+    types: [labeled]
+
 jobs:
   # Build and test this packcage on HPC
   ci-hpc:
     name: ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     uses: ./.github/workflows/reusable-ci-hpc.yml
     with:
       eccodes-python: ecmwf/eccodes-python@${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  # Trigger the workflow on push to master or develop, except tag creation
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+    tags-ignore:
+      - '**'
+
+  # Trigger the workflow on pull request
+  pull_request: ~
+
+  # Trigger the workflow manually
+  workflow_dispatch: ~
+
+jobs:
+  # Build and test this packcage on HPC
+  ci-hpc:
+    name: ci-hpc
+    uses: ./.github/workflows/reusable-ci-hpc.yml
+    with:
+      eccodes-python: ecmwf/eccodes-python@${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -1,0 +1,10 @@
+# Manage labels of pull requests that originate from forks
+name: label-public-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -1,0 +1,31 @@
+name: reusable-ci-hpc
+
+on:
+  workflow_call:
+    inputs:
+      eccodes:
+        required: false
+        type: string
+      eccodes-python:
+        required: false
+        type: string
+
+jobs:
+  ci-hpc:
+    name: ci-hpc
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-hpc.yml@v2
+    with:
+      name-prefix: eccodes-python-
+      build-inputs: |
+        --package: ${{ inputs.eccodes-python || 'ecmwf/eccodes-python@develop' }}
+        --python: 3.10
+        --env: |
+          ECCODES_SAMPLES_PATH=../install/eccodes/share/eccodes/samples
+          ECCODES_DEFINITION_PATH=../install/eccodes/share/eccodes/definitions
+        --modules: |
+          ecbuild
+          ninja
+        --dependencies: |
+          ${{ inputs.eccodes || 'ecmwf/eccodes@develop' }}
+        --parallel: 64
+    secrets: inherit


### PR DESCRIPTION
Adds a reusable workflow to run CI on HPC.
Trigger HPC CI on push to master/develop or pull request (public PR must be first approved by adding lablel `approved-for-ci`)