### PR TITLE
Upgrade setuptools before running CI

### DIFF
--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-cov isort black flake8
+          pip install --upgrade setuptools wheel
 
       - if: matrix.method == 'conda'
         run: conda install 'eccodes>=2.27.0'

--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
 

--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -15,7 +15,7 @@ jobs:
     name: Code QA
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pip install black flake8 isort
       - run: black --version
       - run: isort --check .
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v2
         with:
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Seeing intermittent build failures on MacOS but the problem is not clear.

This PR also upgrades a couple of GitHub Actions we're using: actions/checkout and actions/setup-python