### PR TITLE
Add pypi CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,11 @@
+name: cd
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  pypi:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    secrets: inherit

--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -27,12 +27,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        method: ["conda", "ecmwflibs"]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        method: ['conda', 'ecmwflibs']
         exclude:
           - platform: macos-latest
-            python-version: "3.9"
-            method: "ecmwflibs"
+            python-version: '3.9'
+            method: 'ecmwflibs'
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.platform }} (${{ matrix.method }})
     runs-on: ${{ matrix.platform }}
@@ -79,8 +79,8 @@ jobs:
       - run: pytest
         if: matrix.method == 'conda' && matrix.platform == 'windows-latest'
         env:
-          ECCODES_DEFINITION_PATH: "C:/Miniconda/Library/share/eccodes/definitions"
-          ECCODES_SAMPLES_PATH: "C:/Miniconda/Library/share/eccodes/samples"
+          ECCODES_DEFINITION_PATH: 'C:/Miniconda/Library/share/eccodes/definitions'
+          ECCODES_SAMPLES_PATH: 'C:/Miniconda/Library/share/eccodes/samples'
 
       - run: pytest
         if: matrix.method != 'conda' || matrix.platform != 'windows-latest'
@@ -89,39 +89,4 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
-        if: "false"
-
-  deploy:
-    if: ${{ github.event_name == 'release' }}
-
-    name: Upload to Pypi
-    needs: checks
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-
-      - name: Check version
-        run: |
-          release=${GITHUB_REF##*/}
-          version=$(python setup.py --version)
-          test "$release" == "$version"
-
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py sdist
-          twine upload dist/*
+        if: 'false'


### PR DESCRIPTION
Use a reusable workflow for pypi CD.
Keep the `check-and-publish.yml` wf for now, as it tests also on mac and windows, which we don't support yet.