### PR TITLE
Add qa to GitHub ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     with:
       eccodes-python: ecmwf/eccodes-python@${{ github.event.pull_request.head.sha || github.sha }}
       codecov_upload: true
+      python_qa: true
     secrets: inherit
 
   # Build downstream packages on HPC


### PR DESCRIPTION
This should start testing code with isort, flake8 and black when the ci runs.