### PR TITLE
Update to artifact actions v4

### DIFF
--- a/.github/workflows/build-wheel-linux.yml
+++ b/.github/workflows/build-wheel-linux.yml
@@ -53,7 +53,7 @@ jobs:
 
       ################################################################
       - run: ./scripts/wheel-linux.sh 3.8
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload wheel 3.8
         with:
           name: wheel-manylinux2014-3.8
@@ -61,7 +61,7 @@ jobs:
 
       # ################################################################
       - run: ./scripts/wheel-linux.sh 3.9
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload wheel 3.9
         with:
           name: wheel-manylinux2014-3.9
@@ -69,7 +69,7 @@ jobs:
 
       # ################################################################
       - run: ./scripts/wheel-linux.sh 3.10
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload wheel 3.10
         with:
           name: wheel-manylinux2014-3.10
@@ -77,7 +77,7 @@ jobs:
 
       # ################################################################
       - run: ./scripts/wheel-linux.sh 3.11
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload wheel 3.11
         with:
           name: wheel-manylinux2014-3.11
@@ -85,7 +85,7 @@ jobs:
 
       # ################################################################
       - run: ./scripts/wheel-linux.sh 3.12
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload wheel 3.12
         with:
           name: wheel-manylinux2014-3.12
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheel-manylinux2014-${{ matrix.python-version }}
   
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheel-manylinux2014-${{ matrix.python-version }}
           path: artifact-${{ matrix.python-version }}


### PR DESCRIPTION
Update upload-artifact and download-artifact actions to v4 as v3 and older are deprecated and will soon be removed. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/