### PR TITLE
Allow setting of array in `highlevel.Message.set` 

### DIFF
--- a/eccodes/highlevel/message.py
+++ b/eccodes/highlevel/message.py
@@ -105,16 +105,13 @@ class Message:
         if check_values:
             # Check values just set
             for name, value in key_values.items():
-                cast_value = value
                 if type(value) in _TYPES_MAP.values():
                     saved_value = self.get(f"{name}:{type(value).__name__}")
                 else:
                     saved_value = self.get(name)
-                    if not isinstance(value, type(saved_value)):
-                        cast_value = type(saved_value)(value)
-                if not np.all(saved_value == cast_value):
+                if not np.all(saved_value == value):
                     raise ValueError(
-                        f"Unexpected retrieved value {saved_value} for key {name}. Expected {cast_value}"
+                        f"Unexpected retrieved value {saved_value} for key {name}. Expected {value}"
                     )
 
     def get_array(self, name):

--- a/eccodes/highlevel/message.py
+++ b/eccodes/highlevel/message.py
@@ -1,6 +1,8 @@
 import io
 from contextlib import contextmanager
 
+import numpy as np
+
 import eccodes
 
 _TYPES_MAP = {
@@ -95,21 +97,22 @@ class Message:
 
         for name, value in key_values.items():
             with raise_keyerror(name):
-                eccodes.codes_set(self._handle, name, value)
+                if np.ndim(value) > 0:
+                    eccodes.codes_set_array(self._handle, name, value)
+                else:
+                    eccodes.codes_set(self._handle, name, value)
 
         if check_values:
             # Check values just set
             for name, value in key_values.items():
                 cast_value = value
-                if isinstance(value, str):
-                    saved_value = eccodes.codes_get_string(self._handle, name)
-                elif isinstance(value, int):
-                    saved_value = eccodes.codes_get_long(self._handle, name)
+                if type(value) in _TYPES_MAP.values():
+                    saved_value = self.get(f"{name}:{type(value).__name__}")
                 else:
                     saved_value = self.get(name)
                     if not isinstance(value, type(saved_value)):
                         cast_value = type(saved_value)(value)
-                if saved_value != cast_value:
+                if not np.all(saved_value == cast_value):
                     raise ValueError(
                         f"Unexpected retrieved value {saved_value} for key {name}. Expected {cast_value}"
                     )

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -59,6 +59,7 @@ def test_message_set_plain():
         message.set("centre", "ecmf")
         vals = np.arange(message.get("numberOfValues"), dtype=np.float32)
         message.set_array("values", vals)
+        message.set("values", vals)
         message.set_missing(missing_key)
         assert message.get("centre") == "ecmf"
         assert np.all(message.get("values") == vals)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -59,6 +59,7 @@ def test_message_set_plain():
         message.set("centre", "ecmf")
         vals = np.arange(message.get("numberOfValues"), dtype=np.float32)
         message.set_array("values", vals)
+        assert np.all(message.get("values") == vals)
         message.set("values", vals)
         message.set_missing(missing_key)
         assert message.get("centre") == "ecmf"


### PR DESCRIPTION
Add equivalent ability to set array values using `highlevel.Message.set`, matching existing functionality of `highlevel.Message.get`. 