### PR TITLE
Use manylinux_2_28-x64 in build-wheel-linux.yml

### DIFF
--- a/.github/workflows/build-wheel-linux.yml
+++ b/.github/workflows/build-wheel-linux.yml
@@ -42,12 +42,12 @@ jobs:
     # if: false  # for temporarily disabling for debugging
 
     runs-on: [self-hosted, Linux, platform-builder-Rocky-8.6]
-    container: dockcross/manylinux2014-x64:latest
+    container: dockcross/manylinux_2_28-x64:latest
 
-    name: Build manylinux2014
+    name: Build manylinux_2_28-x64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: ./scripts/build-linux.sh
 
@@ -106,7 +106,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
 
       - run: mkdir artifact-${{ matrix.python-version }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This fixes the issue we saw when trying to build the Linux wheel via GitHub Actions. It has now been run separately, and the wheels uploaded to PyPi (including the source wheel), so this just needs to be merged into develop for the next time.