### PR TITLE
highlevel: add (rudimentary) BUFR support

### DIFF
--- a/eccodes/highlevel/__init__.py
+++ b/eccodes/highlevel/__init__.py
@@ -1,2 +1,2 @@
-from .message import GRIBMessage, Message  # noqa
+from .message import BUFRMessage, GRIBMessage, Message  # noqa
 from .reader import FileReader, MemoryReader, StreamReader  # noqa

--- a/eccodes/highlevel/message.py
+++ b/eccodes/highlevel/message.py
@@ -33,7 +33,7 @@ class Message:
 
     def copy(self):
         """Create a copy of the current message"""
-        return Message(eccodes.codes_clone(self._handle))
+        return self.__class__(eccodes.codes_clone(self._handle))
 
     def __copy__(self):
         return self.copy()
@@ -240,6 +240,24 @@ class Message:
     def get_buffer(self):
         """Return a buffer containing the encoded message"""
         return eccodes.codes_get_message(self._handle)
+
+
+class BUFRMessage(Message):
+    def __init__(self, handle):
+        super().__init__(handle)
+
+    def pack(self):
+        """Pack the underlying data"""
+        self.set("pack", 1, check_values=False)
+
+    def unpack(self):
+        """Unpack the underlying data"""
+        self.set("unpack", 1, check_values=False)
+
+    @classmethod
+    def from_samples(cls, name):
+        """Create a message from a sample"""
+        return cls(eccodes.codes_bufr_new_from_samples(name))
 
 
 class GRIBMessage(Message):


### PR DESCRIPTION
* Modifies `Message.copy` to support any `Message` subclass
* Adds `BUFRMessage` class with `pack`, `unpack` and `from_samples` methods
* Adds a `kind` argument to the reader constructors (defaults to GRIB for backwards compatibility). Only GRIB and BUFR are supported.