### PR TITLE
Fix/source dist

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,5 +24,12 @@ jobs:
   pypi:
     needs: [wheel-windows]
     uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    with:
+      env_vars: |
+        {
+          "DEPEND_ON_ECCODESLIB": "1"
+        }
+      buildargs: --no-isolation
     secrets: inherit
+    
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ import sys
 
 import setuptools
 
+binary = os.getenv("DEPEND_ON_ECCODESLIB", "") == "1"
+
 
 def read(path):
     file_path = os.path.join(os.path.dirname(__file__), *path.split("/"))
@@ -90,8 +92,13 @@ install_requires += [
     "attrs",
     "cffi",
     "findlibs",
-    "eccodeslib;platform_system!='Windows'",
 ]
+
+# only add eccodeslib as dependency if building a distribution that should depend on it
+if binary:
+    install_requires += [
+        "eccodeslib;platform_system!='Windows'",
+    ]
 
 setuptools.setup(
     name="eccodes",


### PR DESCRIPTION
### Description
Fixes ecmwf/eccodes#372. The only change in behaviour that might not be expected is that now a developer who clones the eccodes-python repo and does `pip install -e .` will *not* get eccodeslib installed automatically - they will have to manually install it if they wish it to be there.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 