### PR TITLE
Fixtoxsyntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,17 @@
 # Run the container with:
 #   docker run --rm -it -v `pwd`:/src eccodes-python
 #
-FROM python:3.9-slim
+FROM bopen/ubuntu-pyenv:latest
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
-        build-essential \
         libeccodes0 \
  && rm -rf /var/lib/apt/lists/*
 
 COPY . /src/
 
-RUN --mount=type=cache,target=/root/.cache/pip cd /src \
-    && pip install --upgrade pip \
+RUN cd /src \
     && make local-install-test-req \
     && make local-develop \
     && make local-install-dev-req \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,19 @@
 # Run the container with:
 #   docker run --rm -it -v `pwd`:/src eccodes-python
 #
-FROM bopen/ubuntu-pyenv:latest
+FROM python:3.9-slim
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
+        build-essential \
         libeccodes0 \
  && rm -rf /var/lib/apt/lists/*
 
 COPY . /src/
 
-RUN cd /src \
+RUN --mount=type=cache,target=/root/.cache/pip cd /src \
+    && pip install --upgrade pip \
     && make local-install-test-req \
     && make local-develop \
     && make local-install-dev-req \

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = docs, py38, py37, py36, py35, pypy3, deps
 
 [testenv]
-passenv = WHEELHOUSE PIP_FIND_LINKS PIP_WHEEL_DIR PIP_INDEX_URL
+passenv = WHEELHOUSE,PIP_FIND_LINKS,PIP_WHEEL_DIR,PIP_INDEX_URL
 setenv = PYTHONPATH = {toxinidir}
 deps = -r{toxinidir}/ci/requirements-tests.txt
 commands = pytest -v --flakes --cache-clear --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
### Description

Fix format of tox.ini for https://github.com/ecmwf/eccodes-python/issues/160

`tox.tox_env.errors.Fail: pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'WHEELHOUSE PIP_FIND_LINKS PIP_WHEEL_DIR PIP_INDEX_URL'
`
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 